### PR TITLE
Change annotation API to focus on annotating tables rather than models 

### DIFF
--- a/lib/acts_as_rdfable.rb
+++ b/lib/acts_as_rdfable.rb
@@ -1,6 +1,7 @@
 require 'active_record'
 require "acts_as_rdfable/railtie"
 require 'acts_as_rdfable/acts_as_rdfable_core'
+require 'acts_as_rdfable/migration_annotations'
 require 'acts_as_rdfable/active_record'
 require 'acts_as_rdfable/rdf_annotation'
 

--- a/lib/acts_as_rdfable/active_record.rb
+++ b/lib/acts_as_rdfable/active_record.rb
@@ -1,5 +1,6 @@
 module ActiveRecord
   ActiveSupport.on_load(:active_record) do
     ActiveRecord::Base.send :include, ActsAsRdfable::ActsAsRdfableCore
+    ActiveRecord::Migration::Current.send :include, ActsAsRdfable::MigrationAnnotations
   end
 end

--- a/lib/acts_as_rdfable/acts_as_rdfable_core.rb
+++ b/lib/acts_as_rdfable/acts_as_rdfable_core.rb
@@ -4,6 +4,14 @@ module ActsAsRdfable::ActsAsRdfableCore
   class_methods do
     def acts_as_rdfable(&configuration_block)
       raise InvalidClassError unless self < ActiveRecord::Base
+
+      define_method :rdf_annotations do
+        RdfAnnotation.for_table(self.table_name)
+      end
+
+      define_method :rdf_annotation_for_attr do |attr|
+        RdfAnnotation.for_table_column(self.table_name, attr)
+      end
     end
   end
 end

--- a/lib/acts_as_rdfable/acts_as_rdfable_core.rb
+++ b/lib/acts_as_rdfable/acts_as_rdfable_core.rb
@@ -1,35 +1,9 @@
 module ActsAsRdfable::ActsAsRdfableCore
   extend ActiveSupport::Concern
 
-  class RdfConfig
-    attr_accessor :mapping
-
-    def initialize
-      @mapping = {}
-    end
-
-    def add_mapping_option(attr)
-      self.define_singleton_method(attr) do |has_predicate:|
-        mapping[attr] = has_predicate
-      end
-    end
-  end
-
   class_methods do
     def acts_as_rdfable(&configuration_block)
       raise InvalidClassError unless self < ActiveRecord::Base
-
-      config = RdfConfig.new
-      self.column_names.each do |name|
-        config.add_mapping_option(name)
-      end
-
-      configuration_block.call(config)
-      config.mapping.each do |column_name, rdf_predicate|
-        annotation = RdfAnnotation.for_table(self.table_name).find_or_initialize_by(column: column_name)
-        annotation.predicate = rdf_predicate.to_s
-        annotation.save!
-      end
     end
   end
 end

--- a/lib/acts_as_rdfable/migration_annotations.rb
+++ b/lib/acts_as_rdfable/migration_annotations.rb
@@ -16,23 +16,23 @@ module ActsAsRdfable::MigrationAnnotations
     end
   end
 
-  def add_rdf_table_annotation(table:, &configuration_block)
-    return delete_table_annotation(table) if reverting?
+  def add_rdf_table_annotations(for_table:, &configuration_block)
+    return delete_table_annotations(for_table) if reverting?
 
     config = RdfConfig.new
 
     configuration_block.call(config)
 
     config.mapping.each do |column_name, rdf_predicate|
-      annotation = RdfAnnotation.for_table(table).find_or_initialize_by(column: column_name)
+      annotation = RdfAnnotation.for_table(for_table).find_or_initialize_by(column: column_name)
       annotation.predicate = rdf_predicate.to_s
       annotation.save!
     end
   end
 
-  def remove_rdf_table_annotation(table)
+  def remove_rdf_table_annotations(table)
     irreversible! %Q(Cannot reverse deletion of RDF annotations for table "#{table}")
-    delete_table_annotation(table)
+    delete_table_annotations(table)
   end
 
   def add_rdf_column_annotation(table, column, has_predicate:)
@@ -50,7 +50,7 @@ module ActsAsRdfable::MigrationAnnotations
 
   private
 
-  def delete_table_annotation(table)
+  def delete_table_annotations(table)
     RdfAnnotation.for_table(table).destroy_all
   end
 

--- a/lib/acts_as_rdfable/migration_annotations.rb
+++ b/lib/acts_as_rdfable/migration_annotations.rb
@@ -1,0 +1,64 @@
+module ActsAsRdfable::MigrationAnnotations
+  extend ActiveSupport::Concern
+
+  class RdfConfig
+    attr_accessor :mapping
+
+    def initialize
+      @mapping = {}
+    end
+
+    def method_missing(name, *args, &block)
+      raise ArgumentError, 'Must specify a predicate' unless args.count == 1
+      arg = args.first
+      raise ArgumentError, "Usage: t.#{name} has_predicate: foo" unless arg.is_a?(Hash) && arg.key?(:has_predicate)
+      mapping[name] = arg[:has_predicate]
+    end
+  end
+
+  def add_rdf_table_annotation(table:, &configuration_block)
+    return delete_table_annotation(table) if reverting?
+
+    config = RdfConfig.new
+
+    configuration_block.call(config)
+
+    config.mapping.each do |column_name, rdf_predicate|
+      annotation = RdfAnnotation.for_table(table).find_or_initialize_by(column: column_name)
+      annotation.predicate = rdf_predicate.to_s
+      annotation.save!
+    end
+  end
+
+  def remove_rdf_table_annotation(table)
+    irreversible! %Q(Cannot reverse deletion of RDF annotations for table "#{table}")
+    delete_table_annotation(table)
+  end
+
+  def add_rdf_column_annotation(table, column, has_predicate:)
+    return delete_column_annotation(table, column) if reverting?
+
+    annotation = RdfAnnotation.for_table(table).find_or_initialize_by(column: column)
+    annotation.predicate = has_predicate.to_s
+    annotation.save!
+  end
+
+  def remove_rdf_column_annotation(table, column)
+    irreversible! %Q(Cannot reverse deletion of RDF annotations for "#{table}"."#{column}")
+    delete_column_annotation(table, column)
+  end
+
+  private
+
+  def delete_table_annotation(table)
+    RdfAnnotation.for_table(table).destroy_all
+  end
+
+  def delete_column_annotation(table, column)
+    RdfAnnotation.for_table_column(table, column).destroy_all
+  end
+
+  def irreversible!(msg)
+    raise ActiveRecord::IrreversibleMigration, msg if reverting?
+  end
+end

--- a/lib/acts_as_rdfable/rdf_annotation.rb
+++ b/lib/acts_as_rdfable/rdf_annotation.rb
@@ -4,4 +4,5 @@ class RdfAnnotation < ActiveRecord::Base
   validates :predicate, presence: true
 
   scope :for_table, ->(table_name) { where(table: table_name) }
+  scope :for_table_column, ->(table_name, column_name) { for_table(table).where(column: column_name) }
 end

--- a/lib/acts_as_rdfable/rdf_annotation.rb
+++ b/lib/acts_as_rdfable/rdf_annotation.rb
@@ -4,5 +4,5 @@ class RdfAnnotation < ActiveRecord::Base
   validates :predicate, presence: true
 
   scope :for_table, ->(table_name) { where(table: table_name) }
-  scope :for_table_column, ->(table_name, column_name) { for_table(table).where(column: column_name) }
+  scope :for_table_column, ->(table_name, column_name) { for_table(table_name).where(column: column_name) }
 end


### PR DESCRIPTION
Changes the thrust of the gem, to focus on providing annotations for tables via migrations rather than doing the annotations dynamically in a model. 

The rationale here is that by controlling the annotations via notations we can put one codebase "in-charge" of the migrations that define the annotations, but allow others to read them out without worry of each codebase clobbering the other as different definitions in different models fall out of sync.